### PR TITLE
[Implemented by Claude Code] Add direct Markdown source routes for AEO Layer 4

### DIFF
--- a/src/pages/404.test.tsx
+++ b/src/pages/404.test.tsx
@@ -81,4 +81,13 @@ describe("NotFoundPage", () => {
     const { container } = render(<Head {...mockPageProps} />);
     expect(container.querySelector("title")).toHaveTextContent("Not found");
   });
+
+  it("renders alternate Markdown link in head", () => {
+    const { container } = render(<Head {...mockPageProps} />);
+    const link = container.querySelector(
+      'link[rel="alternate"][type="text/markdown"]',
+    ) as HTMLLinkElement | null;
+    expect(link).toBeInTheDocument();
+    expect(link?.getAttribute("href")).toBe("/404.md");
+  });
 });

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -36,4 +36,9 @@ const NotFoundPage = () => {
 
 export default NotFoundPage;
 
-export const Head: HeadFC = () => <title>Not found</title>;
+export const Head: HeadFC = () => (
+  <>
+    <title>Not found</title>
+    <link rel="alternate" type="text/markdown" href="/404.md" />
+  </>
+);

--- a/src/pages/contact-form.test.tsx
+++ b/src/pages/contact-form.test.tsx
@@ -38,4 +38,13 @@ describe("ContactFormPage Head", () => {
     expect(meta).toBeInTheDocument();
     expect(meta?.content).toBe("Send a message to Dennis Lo");
   });
+
+  it("renders alternate Markdown link in head", () => {
+    const { container } = render(<Head />);
+    const link = container.querySelector(
+      'link[rel="alternate"][type="text/markdown"]',
+    ) as HTMLLinkElement | null;
+    expect(link).toBeInTheDocument();
+    expect(link?.getAttribute("href")).toBe("/contact-form.md");
+  });
 });

--- a/src/pages/contact-form.tsx
+++ b/src/pages/contact-form.tsx
@@ -14,5 +14,6 @@ export const Head = () => (
   <>
     <title>Contact — DLO</title>
     <meta name="description" content="Send a message to Dennis Lo" />
+    <link rel="alternate" type="text/markdown" href="/contact-form.md" />
   </>
 );

--- a/src/pages/index.test.tsx
+++ b/src/pages/index.test.tsx
@@ -103,4 +103,13 @@ describe("IndexPage", () => {
     const { container } = render(<Head />);
     expect(container.querySelector("title")).toHaveTextContent("Who is DLO?");
   });
+
+  it("renders alternate Markdown link in head", () => {
+    const { container } = render(<Head />);
+    const link = container.querySelector(
+      'link[rel="alternate"][type="text/markdown"]',
+    ) as HTMLLinkElement | null;
+    expect(link).toBeInTheDocument();
+    expect(link?.href).toContain("/index.md");
+  });
 });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import Projects from "../components/Projects/Projects";
 import Experience from "../components/Experience/Experience";
 import Education from "../components/Education/Education";
 import SiteFooter from "../components/SiteFooter/SiteFooter";
+import { Head as SharedHead } from "../components/Head/Head";
 
 const IndexPage = () => {
   return (
@@ -24,4 +25,11 @@ const IndexPage = () => {
 
 export default IndexPage;
 
-export { Head } from "../components/Head/Head";
+export function Head() {
+  return (
+    <>
+      <SharedHead />
+      <link rel="alternate" type="text/markdown" href="/index.md" />
+    </>
+  );
+}

--- a/src/scripts/checkAgentsClaudeSync.test.ts
+++ b/src/scripts/checkAgentsClaudeSync.test.ts
@@ -12,10 +12,15 @@ const scriptPath = path.resolve(
 
 const repos: string[] = [];
 
+const cleanEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([k]) => !k.startsWith("GIT_")),
+) as NodeJS.ProcessEnv;
+
 const runGit = (cwd: string, args: string[]) => {
   const result = spawnSync("git", args, {
     cwd,
     encoding: "utf8",
+    env: cleanEnv,
   });
 
   if (result.status !== 0) {
@@ -29,6 +34,7 @@ const runCheck = (cwd: string) =>
   spawnSync("sh", [scriptPath], {
     cwd,
     encoding: "utf8",
+    env: cleanEnv,
   });
 
 const initRepo = () => {

--- a/src/scripts/installGitHooks.test.ts
+++ b/src/scripts/installGitHooks.test.ts
@@ -21,10 +21,15 @@ const docSyncHookPath = path.resolve(
 
 const repos: string[] = [];
 
+const cleanEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([k]) => !k.startsWith("GIT_")),
+) as NodeJS.ProcessEnv;
+
 const runGit = (cwd: string, args: string[]) => {
   const result = spawnSync("git", args, {
     cwd,
     encoding: "utf8",
+    env: cleanEnv,
   });
 
   if (result.status !== 0) {
@@ -72,6 +77,7 @@ describe("install-git-hooks.sh", () => {
     const result = spawnSync("sh", [scriptPath], {
       cwd,
       encoding: "utf8",
+      env: cleanEnv,
     });
 
     expect(result.status).toBe(0);
@@ -99,6 +105,7 @@ describe("install-git-hooks.sh", () => {
     const installResult = spawnSync("sh", [scriptPath], {
       cwd,
       encoding: "utf8",
+      env: cleanEnv,
     });
 
     expect(installResult.status).toBe(0);
@@ -110,7 +117,7 @@ describe("install-git-hooks.sh", () => {
       cwd,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...cleanEnv,
         PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
       },
     });

--- a/src/test-e2e/markdown-source.spec.ts
+++ b/src/test-e2e/markdown-source.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Direct Markdown source routes", () => {
+  test("GET /index.md returns raw Markdown with homepage H1", async ({
+    page,
+  }) => {
+    await page.goto("/index.md");
+    const body = await page.locator("body").textContent();
+    expect(body).toContain("# Who is DLO?");
+  });
+
+  test("GET /contact-form.md returns raw Markdown with contact H1", async ({
+    page,
+  }) => {
+    await page.goto("/contact-form.md");
+    const body = await page.locator("body").textContent();
+    expect(body).toContain("# Contact Dennis Lo");
+  });
+
+  test("GET /404.md returns raw Markdown with 404 H1", async ({ page }) => {
+    await page.goto("/404.md");
+    const body = await page.locator("body").textContent();
+    expect(body).toContain("# Page Not Found");
+  });
+
+  test("homepage HTML route still renders", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveURL("/");
+    await expect(page.locator("body")).not.toBeEmpty();
+    // Page should render React content, not raw Markdown
+    const body = await page.locator("body").textContent();
+    expect(body).not.toMatch(/^# /);
+  });
+
+  test("contact-form HTML route still renders", async ({ page }) => {
+    await page.goto("/contact-form");
+    await expect(page).toHaveURL(/contact-form/);
+    await expect(
+      page.getByRole("heading", { name: "Contact Me" }),
+    ).toBeVisible();
+  });
+});

--- a/static/404.md
+++ b/static/404.md
@@ -1,0 +1,13 @@
+[//]: # "Source: src/pages/404.tsx — update this file when the 404 page changes"
+
+# Page Not Found
+
+The requested page does not exist on this site. This is the 404 error page for [dlo.wtf](/).
+
+If you followed a link here, the page may have been moved or removed.
+
+## Useful Destinations
+
+- [Homepage](/): Dennis Lo's profile, services, projects, and experience
+- [Contact](/contact-form): Get in touch with Dennis Lo
+- [Homepage Markdown](/index.md): Clean Markdown source for the homepage

--- a/static/contact-form.md
+++ b/static/contact-form.md
@@ -1,0 +1,25 @@
+[//]: # "Source: src/config.ts — update this file when config changes"
+
+# Contact Dennis Lo
+
+Use this page to contact Dennis Lo about IT consultancy and software engineering services. Dennis trades as Agile IT & Software Limited and is available for contract engagements.
+
+For fastest response, send an email directly to [dennis@dlo.wtf](mailto:dennis@dlo.wtf).
+
+## Best For
+
+- Enquiries about software engineering or IT consultancy contracts
+- Questions about projects, courses, or tools built by Dennis Lo
+- Partnership or collaboration proposals
+
+## Contact Options
+
+- **Contact form**: [/contact-form](/contact-form) — fill in your name, mobile, email, and message
+- **Email**: [dennis@dlo.wtf](mailto:dennis@dlo.wtf)
+- **GitHub**: [github.com/dennislo](https://github.com/dennislo)
+- **LinkedIn**: [linkedin.com/in/dennis-lo-profile](https://www.linkedin.com/in/dennis-lo-profile)
+
+## Related Pages
+
+- [Homepage](/): Full profile, services, projects, and experience
+- [Homepage Markdown](/index.md): Clean Markdown source for the homepage

--- a/static/index.md
+++ b/static/index.md
@@ -1,0 +1,121 @@
+[//]: # "Source: src/config.ts — update this file when config changes"
+
+# Who is DLO?
+
+Personal website of Dennis Lo, IT consultant and software engineer based in London. This page is the canonical Markdown source for the homepage at [dlo.wtf](/).
+
+Dennis Lo (DLO) is available for contract software engineering and IT consultancy engagements. For inquiries, use the [contact form](/contact-form) or email [dennis@dlo.wtf](mailto:dennis@dlo.wtf).
+
+## Summary
+
+I'm Dennis Lo, an IT consultant and software engineer who crafts robust, scalable solutions that solve real problems. I have deep expertise across the full stack, I thrive in fast-paced, collaborative environments and have a proven track record of delivering high-impact projects for clients both locally and internationally.
+
+**Trading as Agile IT & Software Limited** — we deliver enterprise-grade IT consultancy and software engineering services, with specialized expertise in JavaScript, C#, Java, and Bash/Shell. Our proven experience spans diverse industries and complex technical challenges, from system architecture and full-stack development to DevOps automation and legacy system modernization.
+
+## Services
+
+- Full-stack software engineering (JavaScript / TypeScript / C# / Java)
+- System architecture and technical design
+- DevOps automation and CI/CD pipeline implementation
+- Legacy system modernization and replatforming
+- Web platform development and monorepo strategy
+- Contract and freelance software delivery
+
+## Skills
+
+- JavaScript, TypeScript, C#, Java, Bash/Shell
+- React, Node.js
+- Cloud Computing, DevOps
+- Full Stack Development, System Architecture
+
+## Client Sectors
+
+- Advertising & Media
+- HR & Recruitment
+- Retail & Consumer
+- Science & Education
+- Finance & Banking
+- IT & Telecommunications
+
+## Projects
+
+### AI Dev Roundup Newsletter
+
+One concise email. Five minutes. Every Tuesday. Essential AI news & trends, production-ready libraries, and developer tools curated for engineers.
+
+Skills: React, Node.js, AWS
+
+### Chrome Extension Mastery
+
+A comprehensive course covering full-stack Chrome extension development from fundamentals to publishing on the Chrome Web Store.
+
+Skills: JavaScript, Chrome APIs, React
+
+### ExtensionKit
+
+A starter template kit for Chrome extensions with TypeScript, React, and Vite — get from zero to published in minutes.
+
+Skills: TypeScript, React, Vite
+
+## Experience
+
+### Software Engineer (Contractor) — Crosstide / 101 Ways
+
+_Nov 2021 – Present_
+
+- Architected and led the Marks & Spencer web platform monorepo, now used by 200+ engineers
+- Replatformed the basket and checkout application processing millions of orders daily
+- Championed test-driven development, decision logs, and thorough code reviews across the team
+
+### Software Engineer (Contractor) — Pret A Manger
+
+_Mar 2021 – Oct 2021_
+
+- Enhanced high-volume subscription transactions with Chargebee, Commerce Tools, and Adyen
+- Spearheaded engineering practices through full remote pair programming and increased test coverage
+
+### Software Engineer (Contractor) — NatWest Group
+
+_Sep 2018 – Feb 2021_
+
+- Developed a greenfield HR platform from scratch using React, Redux, and Node
+- Collaborated across NLP, legal, insurance, and HR disciplines to deliver NatWest Mentor
+
+### Software Engineer (Contractor) — BCG Digital Ventures
+
+_Apr 2018 – Aug 2018_
+
+- Built a real-time data visualisation platform for an IoT startup (MachineMax)
+- Collaborated with hardware, data science, and ML teams to deliver production-grade dashboards
+
+### Software Engineer (Contractor) — Elsevier
+
+_Apr 2016 – Mar 2018_
+
+- Developed journal home pages for ScienceDirect, serving publications like Cell and The Lancet
+- Designed and built a shared UI library to accelerate cross-team frontend development
+
+### Senior Software Engineer — Starcount
+
+_Sep 2014 – Mar 2016_
+
+- Built the Vibe web app aggregating social media content from Facebook, Twitter, Instagram, and YouTube
+- Architected embeddable web components for third-party integration across web and mobile
+- Designed an enterprise analytics platform with scalable PDF report generation
+
+## Education
+
+### Bachelor of Engineering (B.Eng.), Computer Software Engineering — UNSW
+
+_2003 – 2008_
+
+- Honours Class 1
+- Honours Thesis: Service Oriented Architecture for e-Business Standards
+
+## Contact
+
+- Email: [dennis@dlo.wtf](mailto:dennis@dlo.wtf)
+- GitHub: [github.com/dennislo](https://github.com/dennislo)
+- LinkedIn: [linkedin.com/in/dennis-lo-profile](https://www.linkedin.com/in/dennis-lo-profile)
+- Instagram: [instagram.com/dlo](https://www.instagram.com/dlo)
+- Contact form: [/contact-form](/contact-form)

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -11,3 +11,11 @@ Token counts below are rough estimates based on page content, using the AEO guid
 - [Experience](/#experience): Career history, contract roles, and representative impact (approx. 340 tokens).
 - [Education](/#education): Formal education and academic background (approx. 50 tokens).
 - [Gists](https://gist.github.com/dennislo/public): Public GitHub Gists and code snippets (external; token cost varies).
+
+## Markdown Sources
+
+Clean Markdown source is available at direct `.md` routes.
+
+- [Homepage Markdown](/index.md): Clean source for the homepage profile, services, projects, experience, and education.
+- [Contact Markdown](/contact-form.md): Clean source for contact intent and contact options.
+- [404 Markdown](/404.md): Clean source for fallback navigation.


### PR DESCRIPTION
Static .md files at /index.md, /contact-form.md, and /404.md provide clean Markdown for agent parsing without navigation or visual chrome. Page Head exports include rel="alternate" type="text/markdown" links and llms.txt advertises the new routes under a Markdown Sources section.

Also strip GIT_* env vars in git test helpers so they remain isolated when run inside a git pre-commit hook context.

## Description

<!-- Describe your changes in detail. Add screenshots where relevant. -->

## How has this been tested?

<!-- Please describe how you tested your changes. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have ran `npm run lint` and everything passes
- [ ] I have ran `npm run test` and everything passes
- [ ] I have ran `npm run build` and everything built
- [ ] My code follows the code style of this project
- [ ] I have pinned all new external dependencies to an exact version
- [ ] I have updated the documentation where necessary
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests pass
