### PR TITLE
Add guidance hint to contact form message field

### DIFF
--- a/src/components/ContactForm/ContactForm.test.tsx
+++ b/src/components/ContactForm/ContactForm.test.tsx
@@ -77,6 +77,23 @@ describe("ContactForm", () => {
       expect(screen.getByLabelText("Message")).toBeInTheDocument();
     });
 
+    it("renders the persistent hint text for the message field", () => {
+      setup();
+      expect(
+        screen.getByText(
+          "If you would like to work with me please include information about the budget, timeline, project type.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("wires aria-describedby on the message textarea to the hint element", () => {
+      setup();
+      expect(screen.getByLabelText("Message")).toHaveAttribute(
+        "aria-describedby",
+        "message-hint",
+      );
+    });
+
     it('renders the submit button with text "Send Message"', () => {
       setup();
       expect(
@@ -241,6 +258,16 @@ describe("ContactForm", () => {
       expect(screen.getByLabelText("Message")).toHaveAttribute(
         "aria-invalid",
         "true",
+      );
+    });
+
+    it("includes both hint and error in aria-describedby when the message field has an error", async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole("button", { name: "Send Message" }));
+      await screen.findByText("Message is required.");
+      expect(screen.getByLabelText("Message")).toHaveAttribute(
+        "aria-describedby",
+        "message-hint message-error",
       );
     });
 

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -386,6 +386,13 @@ const ContactForm = () => {
             <label htmlFor="message" className={labelClass}>
               Message
             </label>
+            <p
+              id="message-hint"
+              className="text-sm text-gray-500 dark:text-gray-400 mb-1"
+            >
+              If you would like to work with me please include information about
+              the budget, timeline, project type.
+            </p>
             <textarea
               ref={fieldRefs.message as RefObject<HTMLTextAreaElement>}
               id="message"
@@ -397,7 +404,9 @@ const ContactForm = () => {
               rows={5}
               aria-invalid={errors.message !== null ? "true" : undefined}
               aria-describedby={
-                errors.message !== null ? "message-error" : undefined
+                errors.message !== null
+                  ? "message-hint message-error"
+                  : "message-hint"
               }
               className={inputClass}
             />


### PR DESCRIPTION
## Summary

- Adds a persistent visible hint below the **Message** label on the contact form: _"If you would like to work with me please include information about the budget, timeline, project type."_
- Implemented as a `<p id="message-hint">` element rather than a `placeholder` attribute, so the guidance remains readable after the user starts typing
- Wires `aria-describedby` on the textarea to always include `message-hint`, and also `message-error` when a validation error is active

## Why a hint element instead of a placeholder?

The code-reviewer agent flagged that placeholder text disappears on input — a real usability gap for instructional content. A persistent hint element solves this and is announced by screen readers when the field receives focus.

## Changes

| File | Change |
|------|--------|
| `src/components/ContactForm/ContactForm.tsx` | Add `<p id="message-hint">` hint element; update `aria-describedby` |
| `src/components/ContactForm/ContactForm.test.tsx` | Add 3 new tests: hint text renders, `aria-describedby` wired to hint, combined hint+error `aria-describedby` on validation |

## Test plan

- [x] All 141 existing tests pass
- [x] 3 new tests added covering the hint text, aria wiring (no error), and aria wiring (with error)
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Prettier format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153nokdoXhAcpLSEE7JniWJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0153nokdoXhAcpLSEE7JniWJ)_