### PR TITLE
test: remove narration-only comments from e2e specs

### DIFF
--- a/src/test-e2e/contact-form.spec.ts
+++ b/src/test-e2e/contact-form.spec.ts
@@ -31,7 +31,6 @@ test.describe("Contact Form", () => {
   }) => {
     await page.getByRole("button", { name: /send message/i }).click();
 
-    // All five fields must show client-side validation errors.
     // Count assumes Formspree state.errors initialises as null (no server-error alert on first render).
     await expect(page.getByRole("alert").first()).toBeVisible();
     const alerts = page.getByRole("alert");
@@ -76,7 +75,6 @@ test.describe("Contact Form", () => {
   test("form fields have aria-invalid set when errors are shown", async ({
     page,
   }) => {
-    // Trigger validation on email by filling an invalid value and blurring
     await page.getByLabel("Email Address").fill("bad");
     await page.getByLabel("Email Address").blur();
 

--- a/src/test-e2e/header-navigation.spec.ts
+++ b/src/test-e2e/header-navigation.spec.ts
@@ -161,9 +161,8 @@ test.describe("Header navigation", () => {
 
       expect(headerBox).not.toBeNull();
       expect(headingBox).not.toBeNull();
-      // Meaning: after the anchor jump, the heading should start below the fixed header instead of being overlapped by it.
-      // Why this matters: a fixed header can visually cover anchor targets even though the browser technically scrolled
-      // to the right element. The test guards against that regression by checking actual layout in the browser, not just the URL hash.
+      // A fixed header can visually cover anchor targets even though the browser technically scrolled to the right element.
+      // This guards against that regression by checking actual layout, not just the URL hash.
       expect(headingBox!.y).toBeGreaterThanOrEqual(headerBox!.height - 1);
     }
   });

--- a/src/test-e2e/markdown-source.spec.ts
+++ b/src/test-e2e/markdown-source.spec.ts
@@ -29,7 +29,6 @@ test.describe("Direct Markdown source routes", () => {
     await page.goto("/");
     await expect(page).toHaveURL("/");
     await expect(page.locator("body")).not.toBeEmpty();
-    // Page should render React content, not raw Markdown
     const body = await page.locator("body").textContent();
     expect(body).not.toMatch(/^# /);
   });

--- a/src/test-e2e/theme-toggle.spec.ts
+++ b/src/test-e2e/theme-toggle.spec.ts
@@ -36,11 +36,9 @@ test.describe("Theme Toggle", () => {
   });
 
   test("clicking toggle switches from dark back to light", async ({ page }) => {
-    // First switch to dark
     await page.getByRole("button", { name: /switch to dark mode/i }).click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
 
-    // Then switch back to light
     await page.getByRole("button", { name: /switch to light mode/i }).click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
   });
@@ -72,7 +70,6 @@ test.describe("Theme Toggle", () => {
   test("toggle button shows moon icon in light mode (switch to dark)", async ({
     page,
   }) => {
-    // In light mode the button label is "Switch to dark mode"
     await expect(
       page.getByRole("button", { name: /switch to dark mode/i }),
     ).toBeVisible();
@@ -83,7 +80,6 @@ test.describe("Theme Toggle", () => {
   }) => {
     await page.getByRole("button", { name: /switch to dark mode/i }).click();
 
-    // In dark mode the button label is "Switch to light mode"
     await expect(
       page.getByRole("button", { name: /switch to light mode/i }),
     ).toBeVisible();


### PR DESCRIPTION
## Summary

Cleans up code comments across the Playwright e2e spec files (`src/test-e2e/*.spec.ts`). Comments that merely narrate what the test code obviously does were removed; comments that explain genuine, non-obvious reasoning were kept (and tightened where verbose).

No test logic, assertions, selectors, or behavior changed — only comments.

## Changes by file

- **contact-form.spec.ts** — removed two narration comments ("All five fields must show..." and "Trigger validation on email..."). Kept the Formspree `state.errors` assumption comment, which explains why the alert count is exactly 5.
- **theme-toggle.spec.ts** — removed four narration comments ("First switch to dark", "Then switch back to light", and the two "In light/dark mode the button label is..." restatements). Kept the `beforeEach` block explaining why `addInitScript` injects localStorage before load and why the `sessionStorage` guard is needed.
- **header-navigation.spec.ts** — tightened the fixed-header overlap comment from 3 lines to 2, preserving the regression rationale (a fixed header can visually cover anchor targets even when the browser scrolled correctly).
- **markdown-source.spec.ts** — removed the "Page should render React content, not raw Markdown" comment, redundant with the test name and assertion.
- **structured-data.spec.ts** — no comments present; unchanged.

## Test plan

- [ ] No behavioral change; existing e2e suite should pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019jCi98ywCxsyiBYcVvPp3F)_