### PR TITLE
Add TDD workflow and fix agent usage instructions

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -38,13 +38,28 @@ Prohibited: Do NOT use `TodoWrite`, markdown TODO lists, or other trackers. `bd`
 
 Use the `Agent` tool to hand work to the right specialist. Choose the agent based on the task:
 
-- `senior-frontend-engineer` — Gatsby/React/TypeScript implementation and bug fixes
-- `test-writer` — new or updated Jest and React Testing Library coverage
-- `code-reviewer` — post-change review for correctness, regressions, and test adequacy
+- `test-writer` — write unit and integration tests **before** implementation begins; tests must fail first
+- `senior-frontend-engineer` — Gatsby/React/TypeScript implementation and bug fixes; runs **after** failing tests exist
+- `code-reviewer` — post-PR review for correctness, regressions, and test adequacy; runs after a PR is opened
 - `debugger` — reproducing errors, failing tests, broken builds, or unclear behavior
 - `code-health` — cleanup sweeps, stale-pattern detection, tech-debt discovery
 - `Explore` — broad codebase research across many files
 - `general-purpose` — multi-step research or lookups that do not fit a specialist
+
+### Test-Driven Development (TDD) Delegation Order
+
+For every feature or bug fix, delegate in this exact sequence. Do not skip steps or reorder them. Debugging sessions,
+code-health sweeps, and documentation-only changes are exempt and do not require this sequence.
+
+1. **Delegate to `test-writer`** — Write unit and integration tests that describe the expected behavior. If the task
+   involves user journeys, routing, or layout changes, also invoke `.claude/skills/e2e-testing/SKILL.md` to write
+   end-to-end tests. Confirm all tests fail before proceeding. Collect the failing test output — you will pass it to
+   the next agent as context.
+2. **Delegate to `senior-frontend-engineer`** — Implement the minimum code to make the failing tests pass. Include
+   the failing test output from step 1 in the delegation prompt so the agent understands the expected baseline.
+3. **Open a pull request** — Commit and push both the tests and the implementation, then open a PR.
+4. **Delegate to `code-reviewer`** — Review the PR for correctness, regressions, and test adequacy. All Critical and
+   Warning findings must be resolved by the appropriate agent before the PR is merged.
 
 ### Writing a Good Delegation Prompt
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,19 +13,40 @@ refer to it when relevant to the task at hand.
   the "rule of 5". Apply multiple review passes and record only net-new findings each round.
 - Use `.claude/agents/code-health.md` for code-health sweeps, cleanup audits, stale-pattern detection, and follow-up
   maintenance discovery. Check existing `bd` work first and file any new actionable findings in `bd`.
-- Use `.claude/agents/code-reviewer.md` proactively after meaningful code or test changes, and whenever the user asks
-  for a review. Focus on correctness, security, performance, readability, error handling, React best practices, and
-  test adequacy.
+- Use `.claude/agents/code-reviewer.md` for every pull request and whenever meaningful code or test changes are made.
+  Focus on correctness, security, performance, readability, error handling, React best practices, and test adequacy.
+  Apply all suggested fixes using the appropriate specialized agent before the PR is merged.
 - Use `.claude/agents/debugger.md` whenever there are errors, failing tests, broken builds, console issues, or unclear
   behavior. Add plan steps to understand the symptom first, investigate and isolate the cause second, then fix and
   verify.
+- Use `.claude/agents/test-writer.md` to write unit and integration tests **before** implementation begins. Tests must
+  be committed in a failing state to confirm the behavior is not yet implemented. Do not start implementation until
+  tests exist and fail for the right reason.
 - Use `.claude/agents/senior-frontend-engineer.md` for frontend implementation and bug-fix work in Gatsby, React, and
-  TypeScript. Default to this agent when code needs to be written or corrected in the UI layer.
-- Use `.claude/agents/test-writer.md` for unit and integration testing with Jest and React Testing Library.
+  TypeScript. This agent runs **after** the test-writer agent has produced failing tests. The goal is to make those
+  tests pass with the minimum change required.
 - Use `.claude/skills/e2e-testing/SKILL.md` for Playwright work, including new browser tests, updating existing specs,
-  debugging flaky end-to-end coverage, and validating user journeys.
+  debugging flaky end-to-end coverage, and validating user journeys. Write end-to-end tests in addition to unit tests,
+  **before** implementation, so they also start in a failing state.
 - Use `.claude/skills/unit-testing/SKILL.md` when writing or updating Jest and React Testing Library coverage, to
   follow this repo's testing patterns, query priorities, mocking boundaries, and AAA structure.
+
+## Development Workflow
+
+All feature work and bug fixes follow a test-driven development (TDD) cycle. The steps below are mandatory and must
+be executed in order. Debugging sessions, code-health sweeps, and documentation-only changes are exempt from this
+cycle and do not require tests to be written first.
+
+1. **Write failing tests first** — Delegate to `.claude/agents/test-writer.md` for unit and integration tests and to
+   `.claude/skills/e2e-testing/SKILL.md` for end-to-end tests. Run the tests to confirm they fail for the right
+   reason before moving on. Do not skip or defer this step.
+2. **Implement changes** — Delegate to `.claude/agents/senior-frontend-engineer.md` to write the minimum code that
+   makes the failing tests pass. No implementation work starts before failing tests are in place.
+3. **Create a pull request** — Commit and push all changes, then open a pull request. The PR must include both the
+   tests and the implementation together.
+4. **Review the pull request** — Delegate to `.claude/agents/code-reviewer.md` to review for correctness, regressions,
+   and test adequacy. All findings marked Critical or Warning must be resolved by the appropriate agent before the
+   PR is merged.
 
 ## Technology Stack & Development Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,19 +13,40 @@ refer to it when relevant to the task at hand.
   the "rule of 5". Apply multiple review passes and record only net-new findings each round.
 - Use `.claude/agents/code-health.md` for code-health sweeps, cleanup audits, stale-pattern detection, and follow-up
   maintenance discovery. Check existing `bd` work first and file any new actionable findings in `bd`.
-- Use `.claude/agents/code-reviewer.md` proactively after meaningful code or test changes, and whenever the user asks
-  for a review. Focus on correctness, security, performance, readability, error handling, React best practices, and
-  test adequacy.
+- Use `.claude/agents/code-reviewer.md` for every pull request and whenever meaningful code or test changes are made.
+  Focus on correctness, security, performance, readability, error handling, React best practices, and test adequacy.
+  Apply all suggested fixes using the appropriate specialized agent before the PR is merged.
 - Use `.claude/agents/debugger.md` whenever there are errors, failing tests, broken builds, console issues, or unclear
   behavior. Add plan steps to understand the symptom first, investigate and isolate the cause second, then fix and
   verify.
+- Use `.claude/agents/test-writer.md` to write unit and integration tests **before** implementation begins. Tests must
+  be committed in a failing state to confirm the behavior is not yet implemented. Do not start implementation until
+  tests exist and fail for the right reason.
 - Use `.claude/agents/senior-frontend-engineer.md` for frontend implementation and bug-fix work in Gatsby, React, and
-  TypeScript. Default to this agent when code needs to be written or corrected in the UI layer.
-- Use `.claude/agents/test-writer.md` for unit and integration testing with Jest and React Testing Library.
+  TypeScript. This agent runs **after** the test-writer agent has produced failing tests. The goal is to make those
+  tests pass with the minimum change required.
 - Use `.claude/skills/e2e-testing/SKILL.md` for Playwright work, including new browser tests, updating existing specs,
-  debugging flaky end-to-end coverage, and validating user journeys.
+  debugging flaky end-to-end coverage, and validating user journeys. Write end-to-end tests in addition to unit tests,
+  **before** implementation, so they also start in a failing state.
 - Use `.claude/skills/unit-testing/SKILL.md` when writing or updating Jest and React Testing Library coverage, to
   follow this repo's testing patterns, query priorities, mocking boundaries, and AAA structure.
+
+## Development Workflow
+
+All feature work and bug fixes follow a test-driven development (TDD) cycle. The steps below are mandatory and must
+be executed in order. Debugging sessions, code-health sweeps, and documentation-only changes are exempt from this
+cycle and do not require tests to be written first.
+
+1. **Write failing tests first** — Delegate to `.claude/agents/test-writer.md` for unit and integration tests and to
+   `.claude/skills/e2e-testing/SKILL.md` for end-to-end tests. Run the tests to confirm they fail for the right
+   reason before moving on. Do not skip or defer this step.
+2. **Implement changes** — Delegate to `.claude/agents/senior-frontend-engineer.md` to write the minimum code that
+   makes the failing tests pass. No implementation work starts before failing tests are in place.
+3. **Create a pull request** — Commit and push all changes, then open a pull request. The PR must include both the
+   tests and the implementation together.
+4. **Review the pull request** — Delegate to `.claude/agents/code-reviewer.md` to review for correctness, regressions,
+   and test adequacy. All findings marked Critical or Warning must be resolved by the appropriate agent before the
+   PR is merged.
 
 ## Technology Stack & Development Guidelines
 


### PR DESCRIPTION
## Summary

- Adds a mandatory **Test-Driven Development (TDD) cycle** to `CLAUDE.md`: test-writer writes failing tests first, senior-frontend-engineer implements to make them pass, a PR is opened, then code-reviewer reviews before merge.
- Adds a **TDD Delegation Order** section to `orchestrator.md` with an explicit, sequential four-step workflow agents must follow for every feature or bug fix.
- Updates the agent-list bullet points in both files to reflect the new ordering (test-writer before senior-frontend-engineer, code-reviewer trigger scoped to PR creation).

## Rule-of-five review findings and fixes applied

Four passes were run over both files after the initial draft:

| Pass | Finding | Fix applied |
|------|---------|-------------|
| Correctness | `code-reviewer` trigger said "after every pull request" (ambiguous — after open or after merge?) | Changed to "for every pull request" |
| Correctness | `orchestrator.md` TDD step 1 attributed e2e tests to `test-writer`, which only handles Jest/RTL | Clarified that e2e tests use `.claude/skills/e2e-testing/SKILL.md` separately |
| Completeness | No exemption stated for debugging, code-health, and docs work | Added explicit exemption in both files |
| Maintainability | orchestrator step 1 phrasing addressed the delegated agent rather than the orchestrator reading it | Rephrased to clarify the orchestrator collects and passes failing test output to the next delegation |
| Maintainability | "alongside unit tests" implied parallel execution | Changed to "in addition to unit tests" |

No contractions were found in either file.

## Test plan

- [ ] Read `CLAUDE.md` and confirm the Development Workflow section is present, ordered correctly, and contraction-free.
- [ ] Read `.claude/agents/orchestrator.md` and confirm the TDD Delegation Order section is present and the e2e exemption is accurate.
- [ ] Verify no existing agent or skill references were removed or broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gCAqGmEMSJQq3F4bw9tkx

---
_Generated by [Claude Code](https://claude.ai/code/session_011gCAqGmEMSJQq3F4bw9tkx)_